### PR TITLE
add travis-ci build status badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/IT-tomoya/audio_app.svg?branch=master)](https://travis-ci.org/IT-tomoya/audio_app)
+
 音声ファイルアップロードサービス  
 
 - アカウント不要で利用可能  


### PR DESCRIPTION
travis-ci のステータスバッジを README に追加しました。